### PR TITLE
Potential fix for code scanning alert no. 75: Code injection

### DIFF
--- a/buggy_python_code.py
+++ b/buggy_python_code.py
@@ -24,15 +24,25 @@ def print_nametag(format_string, person):
 
 
 def fetch_website(urllib_version, url):
-    # Import the requested version (2 or 3) of urllib
-    exec(f"import urllib{urllib_version} as urllib", globals())
+    # Map allowed versions to their corresponding modules
+    urllib_modules = {
+        "2": "urllib2",
+        "3": "urllib3"
+    }
+    
+    # Validate the urllib_version input
+    if urllib_version not in urllib_modules:
+        raise ValueError("Invalid urllib version. Allowed values are '2' or '3'.")
+    
+    # Dynamically import the correct module
+    urllib = __import__(urllib_modules[urllib_version])
+    
     # Fetch and print the requested URL
- 
     try: 
         http = urllib.PoolManager()
         r = http.request('GET', url)
-    except:
-        print('Exception')
+    except Exception as e:
+        print(f'Exception: {e}')
 
 
 def load_yaml(filename):


### PR DESCRIPTION
Potential fix for [https://github.com/Moebasim/PV080_buggy_code/security/code-scanning/75](https://github.com/Moebasim/PV080_buggy_code/security/code-scanning/75)

To fix the issue, we need to eliminate the use of `exec` and replace it with a safer alternative. Instead of dynamically importing a module based on user input, we can use a predefined mapping of allowed versions (`2` or `3`) to their corresponding modules. This ensures that only valid and safe inputs are processed, and arbitrary code execution is prevented.

The changes will involve:
1. Replacing the `exec` statement with a dictionary-based mapping for `urllib_version`.
2. Validating the `urllib_version` input to ensure it is one of the allowed values (`2` or `3`).
3. Raising an error or returning a meaningful response if the input is invalid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
